### PR TITLE
Fix NullArrayIndex in Trace-xDscOperation

### DIFF
--- a/xDscDiagnostics.psm1
+++ b/xDscDiagnostics.psm1
@@ -707,12 +707,10 @@ function Get-AllGroupedDscEvents
                          4097 = 6;
                          4103 = 5;
                          4104 = 4}
-    $cimErrorId = 4131
-    $errorText = ""
     $outputErrorMessage = ""
     $eventId = $errorEvent.Id
     $propertyIndex = $requiredPropertyIndex[$eventId]
-    if($propertyIndex -ne -1)
+    if($propertyIndex -and $propertyIndex -ne -1)
     {
 
         #This means You need just the property from the indices hash


### PR DESCRIPTION
This fixes the following error:

```
Index operation failed; the array index evaluated to null.
At C:\Program Files\WindowsPowerShell\Modules\xDscDiagnostics\2.7.0.0\xDscDiagnostics.psm1:719 char:9
+         $outputErrorMessage = $errorEvent.Properties[$propertyIndex]. ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : NullArrayIndex
```

The error happens on Operational log contains the message which does not have line-return between "Job {GUID}" and the actual message. Example is:
```
Job {8F9D8BC6-91A5-11E8-8441-00505684AB54} : Details logging completed for C:\Windows\System32\Configuration\ConfigurationStatus\{8F9D8BC6-91A5-11E8-8441-00505684AB54}-0.details.json.                                                        
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdscdiagnostics/47)
<!-- Reviewable:end -->
